### PR TITLE
Workaround for 16 color Xresources

### DIFF
--- a/input.go
+++ b/input.go
@@ -252,6 +252,9 @@ func inputXterm(filename string) ([]color.Color, error) {
 			return nil, err
 		}
 		colors = append(colors, col)
+		if len(colorlines) < 16 && i < 16 - len(colorlines) {
+			colors = append(colors, col)
+		}
 	}
 
 	return colors, nil


### PR DESCRIPTION
in case in the Xres file there are less than 16 colors. Needed it myself.
