### PR TITLE
Added support for kitty, both input and output

### DIFF
--- a/format.go
+++ b/format.go
@@ -91,4 +91,10 @@ var formats = []Format{
 		flagName:     "gnome-terminal",
 		output:       printGnomeDConf,
 	},
+	{
+		friendlyName: "Kitty Terminal",
+		flagName:     "kitty",
+		output:       printKittyTerm,
+		input:        inputKittyTerm,
+	},
 }

--- a/input.go
+++ b/input.go
@@ -256,3 +256,48 @@ func inputXterm(filename string) ([]color.Color, error) {
 
 	return colors, nil
 }
+
+func inputKittyTerm(filename string) ([]color.Color, error) {
+	// Read in file
+	config, err := readFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	// Split into lines
+	lines := strings.Split(config, "\n")
+
+	// Remove all spaces
+	//for i, l := range lines {
+	//	lines[i] = strings.Replace(l, " ", "", -1)
+	//}
+
+	colorlines := make([]string, 0)
+	// Search for lines containing color information
+	re := regexp.MustCompile("^color[0-9]*")
+	for _, l := range lines {
+		if len(re.FindAllString(l, 1)) != 0 {
+			colorlines = append(colorlines, l)
+		}
+	}
+
+	// Extract and parse colors
+	// TODO: Sort by number first?
+	colors := make([]color.Color, 0)
+	for _, l := range colorlines {
+		// Assuming the color to be the rightmost half of the last instance of space/tab
+		splits := strings.FieldsFunc(l, KittySplit)
+		colorstring := splits[len(splits)-1]
+		col, err := parseColor(colorstring)
+		if err != nil {
+			return nil, err
+		}
+		colors = append(colors, col)
+	}
+
+	return colors, nil
+}
+
+func KittySplit(r rune) bool {
+    return r == ' ' || r == '\t'
+}

--- a/output.go
+++ b/output.go
@@ -268,3 +268,18 @@ func printGnomeDConf(colors []color.Color) string {
 	output += "\n"
 	return output
 }
+
+func printKittyTerm(colors []color.Color) string {
+	output := ""
+	for i, c := range colors {
+		cc := c.(color.NRGBA)
+		bytes := []byte{byte(cc.R), byte(cc.G), byte(cc.B)}
+		output += "color"
+		output += strconv.Itoa(i)
+		output += "\t#"
+		output += hex.EncodeToString(bytes)
+		output += "\n"
+	}
+
+	return output
+}


### PR DESCRIPTION
This is a fix for issue #5 adding support for kitty term. You can use kitty as both an input and an output.